### PR TITLE
Make the requirements.txt file work

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,4 +1,0 @@
-Here are the required libraries:
-    -pygame
-    -pyGLM
-    -modernglgl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pygame
+pyGLM
+moderngl
+numpy
+Pywavefront


### PR DESCRIPTION
Fix an error when using pip install -r with the requirements.txt file and add a 's' for multiple requirements